### PR TITLE
Doc: generate and add Entity Relationship Diagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ doc/*_doc.log
 
 ext/lib/bin/supl
 ext/lib/bin/libsupl.zip
+
+# Entity Relationship Diagram is a generated file, do not add to version control
+doc/source/images/erd.svg

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -32,7 +32,8 @@ version = re.sub('', '', os.popen('git describe --tags').read().strip())
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinxcontrib.plantuml'
+    'sphinxcontrib.plantuml',
+    'sphinx.ext.imgconverter'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/documentation.rst
+++ b/doc/source/documentation.rst
@@ -87,6 +87,18 @@ following command:
   OK
   Destroying test database for alias 'default'...
 
+Entity Relationship Diagram (ERD)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An Entity Relationship Diagram (ERD) is a visual representation of the database
+schema. It is be automatically generated from the Django models.
+
+``sensordata`` is the Django app that contains the application logic.
+
+.. figure:: images/erd.svg
+
+  Entity Relationship Diagram generated from Django models
+
 LwM2M Server
 ............
 

--- a/doc/tox.ini
+++ b/doc/tox.ini
@@ -5,13 +5,16 @@ skipsdist = true
 [testenv]
 deps =
     -r requirements.txt
+    -r ../server/django/requirements.txt
 
 [testenv:py3-html]
 commands =
+    python ../server/django/manage.py graph_models sensordata -o source/images/erd.svg
     sphinx-build -E -W --keep-going -b html source build/html
 
 [testenv:py3-pdf]
 commands =
+    python ../server/django/manage.py graph_models sensordata -o source/images/erd.svg
     sphinx-build -M latexpdf source build/pdf
 
 [testenv:py3-linkcheck]

--- a/server/django/requirements.txt
+++ b/server/django/requirements.txt
@@ -1,4 +1,10 @@
-Django==5.0.4
+Django==5.0.6
+django-extensions==3.2.3
 requests==2.31.0
 djangorestframework==3.15.1
 whitenoise==6.6.0
+
+# Generation of Entity-Relationship Diagrams
+graphviz==0.20.3
+pyparsing==3.1.2
+pydot==2.0.0

--- a/server/django/server/settings.py
+++ b/server/django/server/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_extensions",
     "rest_framework",
     "sensordata",
 ]
@@ -123,6 +124,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+GRAPH_MODELS = {
+    'group_models': True,
+    }
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/


### PR DESCRIPTION
The heart of the server and application is the database model. Django offers a way to automatically generate the Entity Relationship Diagram from the database model that the Object Relational Mapping (ORM) uses.

Generating the ER-Diagram means that implementation and documentation are automatically up-to-date.