### PR TITLE
scripts: zephyr: separate from server dir

### DIFF
--- a/doc/source/documentation.rst
+++ b/doc/source/documentation.rst
@@ -205,8 +205,7 @@ can be started in emulation with the following command:
 
 .. code-block:: console
 
-  host:lwm2m_server/server$ zephyr_build_run_sim.sh
-
+  host:lwm2m_server$ zephyr_build_run_sim.sh
   *** Booting nRF Connect SDK zephyr-v3.5.0-3024-g7c3e830729b7 ***
   [00:00:00.000,000] <dbg> net_lwm2m_engine: lwm2m_engine_init: LWM2M engine socket receive thread started
   [00:00:00.000,000] <dbg> net_lwm2m_obj_security: security_create: Create LWM2M security instance: 0

--- a/server/net_tools_start.sh
+++ b/server/net_tools_start.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Start networking via net-tools
-../../tools/net-tools/net-setup.sh

--- a/server/zephyr_build_run.sh
+++ b/server/zephyr_build_run.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-## Build and run Zephyr
-cd ../
-#west build -b qemu_x86 fw_test/lwm2m_client -p -- -DCONF=overlay-lwm2m-1.1.conf
-west build -t run

--- a/server/zephyr_build_run_sim.sh
+++ b/server/zephyr_build_run_sim.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-# Start networking via net-tools
-../../tools/net-tools/net-setup.sh &
-
-## Build and run Zephyr
-west build -b qemu_x86 ../../zephyr/samples/net/lwm2m_client -- -DCONF=overlay-lwm2m-1.1.conf
-west build -t run

--- a/zephyr_build_run.sh
+++ b/zephyr_build_run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+## Build and run Zephyr
+west build -p=auto -b qemu_x86 fw_test/lwm2m_client -p -- -DCONF=overlay-lwm2m-1.1.conf
+west build -t run

--- a/zephyr_build_run_sim.sh
+++ b/zephyr_build_run_sim.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Function to stop networking
+cleanup() {
+    ../tools/net-tools/net-setup.sh stop
+}
+
+# Register the cleanup function to be called on the EXIT signal
+trap cleanup EXIT
+
+# Start networking via net-tools
+../tools/net-tools/net-setup.sh start
+
+## Build and run Zephyr
+west build -p=auto -b qemu_x86 ../zephyr/samples/net/lwm2m_client -- -DCONF=overlay-lwm2m-1.1.conf
+west build -t run
+
+cleanup


### PR DESCRIPTION
Move the zephyr start scripts from server dir to root directory. The scripts are used for testing and are not directly related to the server implementation.


@Kappuccino111 I modified the net-setup script which is now running in background by executing the `start` and `stop` command. Can you check if that makes a difference for you?