### PR TITLE
Django: Send data to devices via admin dashboard

### DIFF
--- a/server/django/sensordata/admin.py
+++ b/server/django/sensordata/admin.py
@@ -1,3 +1,7 @@
+import requests
+import logging
+import os
+from django.utils import timezone
 from django.contrib import admin
 from .models import (
     Device,
@@ -9,15 +13,23 @@ from .models import (
     Firmware
 )
 
+log = logging.getLogger('sensordata')
+
+# Check if we run in a container or locally
+LESHAN_URI = os.getenv('LESHAN_URI', 'http://0.0.0.0:8080') + '/api'
+
+
 @admin.register(Device)
 class DeviceAdmin(admin.ModelAdmin):
     list_display = ('device_id', 'name')
     search_fields = ('device_id', 'name')
 
+
 @admin.register(ResourceType)
 class ResourceTypeAdmin(admin.ModelAdmin):
     list_display = ('object_id', 'resource_id', 'name', 'data_type')
     search_fields = ('object_id', 'resource_id', 'name')
+
 
 @admin.register(Resource)
 class ResourceAdmin(admin.ModelAdmin):
@@ -25,11 +37,13 @@ class ResourceAdmin(admin.ModelAdmin):
     search_fields = ('device__device_id', 'resource_type__name')
     list_filter = ('device', 'resource_type', 'timestamp')
 
+
 @admin.register(Event)
 class EventAdmin(admin.ModelAdmin):
     list_display = ('device', 'event_type', 'start_time', 'end_time')
     search_fields = ('device__device_id', 'event_type')
     list_filter = ('device', 'event_type')
+
 
 @admin.register(EventResource)
 class EventResourceAdmin(admin.ModelAdmin):
@@ -37,12 +51,71 @@ class EventResourceAdmin(admin.ModelAdmin):
     search_fields = ('event__event_type', 'resource__resource_type__name')
     list_filter = ('event', 'resource')
 
+
 @admin.register(DeviceOperation)
 class DeviceOperationAdmin(admin.ModelAdmin):
     list_display = ('resource', 'operation_type', 'status', 'timestamp_sent',
                     'retransmit_counter', 'last_attempt')
     search_fields = ('resource__device__device_id', 'operation_type', 'status')
     list_filter = ('resource', 'operation_type', 'status', 'timestamp_sent')
+    readonly_fields = ('status', 'timestamp_sent', 'retransmit_counter',
+                       'last_attempt', 'operation_type')
+
+    def save_model(self, request, obj, form, change):
+        # Update both timestamps, as we handle a manual entry. Automatic
+        # retries would only update the last_attempt
+        obj.last_attempt = timezone.now()
+        obj.timestamp_sent = timezone.now()
+        super().save_model(request, obj, form, change)
+
+        # Get the resource associated with the device operation
+        resource = obj.resource
+        device = resource.device
+        resource_type = resource.resource_type
+
+        # Determine the value based on the type of resource value
+        value = None
+        if resource_type.data_type == 'int':
+            value = resource.int_value
+        elif resource_type.data_type == 'float':
+            value = resource.float_value
+        elif resource_type.data_type == 'string':
+            value = resource.str_value
+        elif resource_type.data_type == 'bool':
+            value = resource.bool_value
+        else:
+            # TODO: maybe an execute operation?
+            log.error('Resource value not found')
+            return
+
+
+        # Construct the URL based on the device, object_id, and resource_id
+        url = (
+            f'{LESHAN_URI}/clients/{device.device_id}/'
+            f'{resource_type.object_id}/0/{resource_type.resource_id}'
+        )
+        params = {'timeout': 5, 'format': 'CBOR'}
+        headers = {'Content-Type': 'application/json'}
+        data = {
+            "id": resource_type.resource_id,
+            "kind": "singleResource",
+            "value": value,
+            "type": resource_type.data_type
+        }
+
+        # Send the request
+        response = requests.put(url, params=params, headers=headers, json=data)
+
+        if response.status_code == 200:
+            log.debug(f'Data sent to device {device.device_id} successfully')
+            log.debug(f'Response: {response.status_code} - {response.json()}')
+            obj.status = 'completed'
+        else:
+            log.error(f'Failed to send data: {response.status_code}')
+            obj.status = 'pending'
+            obj.retransmit_counter += 1
+
+        obj.save()
 
 @admin.register(Firmware)
 class FirmwareAdmin(admin.ModelAdmin):

--- a/server/django/sensordata/admin.py
+++ b/server/django/sensordata/admin.py
@@ -23,12 +23,29 @@ LESHAN_URI = os.getenv('LESHAN_URI', 'http://0.0.0.0:8080') + '/api'
 class DeviceAdmin(admin.ModelAdmin):
     list_display = ('device_id', 'name')
     search_fields = ('device_id', 'name')
+    readonly_fields = ('device_id', 'name')
 
+    def get_model_perms(self, request):
+        return {
+            'add': False,
+            'change': False,
+            'delete': False,
+            'view': True,
+        }
 
 @admin.register(ResourceType)
 class ResourceTypeAdmin(admin.ModelAdmin):
     list_display = ('object_id', 'resource_id', 'name', 'data_type')
     search_fields = ('object_id', 'resource_id', 'name')
+    readonly_fields = ('object_id', 'resource_id', 'name', 'data_type')
+
+    def get_model_perms(self, request):
+        return {
+            'add': False,
+            'change': False,
+            'delete': False,
+            'view': True,
+        }
 
 
 @admin.register(Resource)
@@ -49,7 +66,7 @@ class EventAdmin(admin.ModelAdmin):
 class EventResourceAdmin(admin.ModelAdmin):
     list_display = ('event', 'resource')
     search_fields = ('event__event_type', 'resource__resource_type__name')
-    list_filter = ('event', 'resource')
+    list_filter = ('event', 'resource__resource_type')
 
 
 @admin.register(DeviceOperation)
@@ -57,7 +74,7 @@ class DeviceOperationAdmin(admin.ModelAdmin):
     list_display = ('resource', 'operation_type', 'status', 'timestamp_sent',
                     'retransmit_counter', 'last_attempt')
     search_fields = ('resource__device__device_id', 'operation_type', 'status')
-    list_filter = ('resource', 'operation_type', 'status', 'timestamp_sent')
+    list_filter = ('resource__resource_type', 'operation_type', 'status', 'timestamp_sent')
     readonly_fields = ('status', 'timestamp_sent', 'retransmit_counter',
                        'last_attempt', 'operation_type')
 
@@ -120,5 +137,3 @@ class DeviceOperationAdmin(admin.ModelAdmin):
 @admin.register(Firmware)
 class FirmwareAdmin(admin.ModelAdmin):
     list_display = ('version', 'file_name', 'download_url', 'created_at')
-    search_fields = ('version', 'file_name')
-    list_filter = ('created_at',)

--- a/server/django/server/settings.py
+++ b/server/django/server/settings.py
@@ -31,14 +31,30 @@ CSRF_TRUSTED_ORIGINS = ['https://controlscope.de']
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname} {module}: {message}',
+            'style': '{',
+        },
+    },
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
+            'formatter': 'simple',
         },
     },
     'loggers': {
         '': {  # Root logger
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'sensordata': {
             'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': False,

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "8000:8000"
     networks:
       - mynetwork
+    environment:
+      - LESHAN_URI=http://leshan:8080
 
   leshan:
     build:


### PR DESCRIPTION
Add the capability to send messages to devices from the django dashboard. Once a DeviceOperation Resource gets

- [x] Assign Leshan URI automatically, depending on if running in container or locally
- [x] Add initial resources to the database on initial django start (Static LwM2M Resources)
- [x] DeviceOperations resource read-only from the admin dashboard
- [x] Setup all relevant resources as read-only from the admin dashboard

**Note:** this initial feature set only works for non-queue mode (devices always online). Queued mode requires more work on thee Leshan->Django interfaces so that Leshan updates Django on the current device status (online/offline).

Fixes: #13 